### PR TITLE
Remove usage of DS constant

### DIFF
--- a/config.php
+++ b/config.php
@@ -34,5 +34,5 @@ Kirby::plugin('sylvainjule/annotator', array(
             )
         ),
     ),
-    'fieldMethods' => require_once __DIR__ . DS . 'lib' . DS . 'fieldMethods.php',
+    'fieldMethods' => require_once __DIR__ . '/lib/fieldMethods.php',
 ));


### PR DESCRIPTION
This PR resolves error below (Kirby 3.0):

```
Warning: Use of undefined constant DS - assumed 'DS' (this will throw an Error in a future version of PHP) in /.../vendor/sylvainjule/annotator/config.php on line 37

Warning: Use of undefined constant DS - assumed 'DS' (this will throw an Error in a future version of PHP) in /.../vendor/sylvainjule/annotator/config.php on line 37

Warning: require_once(/.../vendor/sylvainjule/annotatorDSlibDSfieldMethods.php): failed to open stream: No such file or directory in /.../vendor/sylvainjule/annotator/config.php on line 37

Fatal error: require_once(): Failed opening required '/.../vendor/sylvainjule/annotatorDSlibDSfieldMethods.php' (include_path='.:/usr/local/Cellar/php@7.2/7.2.14/share/php@7.2/pear') in /.../vendor/sylvainjule/annotator/config.php on line 37
```