### PR TITLE
Update fieldMethods.php

### DIFF
--- a/lib/fieldMethods.php
+++ b/lib/fieldMethods.php
@@ -23,6 +23,8 @@ return array(
     	return floatval($field->value) * 100;
     },
     'toPercentString' => function($field) {
-    	return floatval($field->value) * 100 . '%';
+        // Floatval isn't locale aware and outputs commas instead of dots for decimal separator
+        // This doesn't work in CSS, which expects a dot
+    	return str_replace(',','.', floatval($field->value) * 100) . '%';
     },
 );


### PR DESCRIPTION
There's an issue with floatval and locales.

It returns "," instead of "." as decimal in some locales. This causes havoc in CSS for positioning as CSS doesn't understand the comma as decimal separator.

AFAIK there's no easy way around this, so I fixed this via a str_replace. This should not cause any breaking changes.